### PR TITLE
feat: remove .gitignore /*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignore everything
-/*
+node_modules
+package-lock.json
+package.json
 
 !.gitignore
 !.gitpod.yml


### PR DESCRIPTION
@alesanchezr  modifique el archivo .gitignore porque estaba ignorando todo y los alumnos al hacer su fork ya agregar su archivo de test no pueden subirlo a su repo y posteriormente entregarlo en breathco