### PR TITLE
Bump for Docker Container version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 {
 	"name": "Node.js",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/javascript-node:0-16",
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:22",
 	"customizations": {
 		"vscode": {
 			"settings": {


### PR DESCRIPTION
This PR updates the Docker Container from the node 16 deprecated version to the LTS node 22 version