### PR TITLE
Update README.md

### DIFF
--- a/.learn/exercises/09-the-first-test/README.md
+++ b/.learn/exercises/09-the-first-test/README.md
@@ -22,9 +22,9 @@ According to our planned functionalities, we will need to write tests to make su
 For example, the test function to make sure that the function `fromEuroToDollar` has been successfully implemented. It is something like this:
 
 ```js
-test("One euro should be 1.07 dollars", function() {
     // Import the function from app.js
     const { fromEuroToDollar } = require('./app.js');
+test("One euro should be 1.07 dollars", function() {
 
     // Use the function like its supposed to be used
     const dollars = fromEuroToDollar(3.5);


### PR DESCRIPTION
Lesson #9 has an error in the Jest Test code given to the student. The code is importing the function AFTER the test is initialized and this causes the test to fail with:

TypeError: fromEuroToDollar is not a function.

So I moved the import to be outside of the test. We can verify this by running the test before and after. Also, back in lesson #6, it was done the correct way 💪